### PR TITLE
Fix issue with blank query string in onReject

### DIFF
--- a/src/main/java/com/auth0/Auth0Filter.java
+++ b/src/main/java/com/auth0/Auth0Filter.java
@@ -44,8 +44,8 @@ public class Auth0Filter implements Filter {
     protected void onReject(ServletRequest req, ServletResponse response, FilterChain next) throws IOException, ServletException {
         HttpServletResponse resp = (HttpServletResponse) response;
         HttpServletRequest request = (HttpServletRequest) req;
-        resp.sendRedirect(request.getContextPath() + onFailRedirectTo + "?"
-				+ request.getQueryString());
+        String queryString = request.getQueryString() == null ? "" : "?" + request.getQueryString();
+        resp.sendRedirect(request.getContextPath() + onFailRedirectTo + queryString);
     }
 
     @Override


### PR DESCRIPTION
If there no query string for the filtered the URL, then when redirecting
to a login URI such as "/login" a null query would be added
"/login?null".

This commit changes the onReject method to only include queryString if
it is non null.