### PR TITLE
relax privacy on auth0servletcallback and cleanup codebase

### DIFF
--- a/src/main/java/com/auth0/Auth0Filter.java
+++ b/src/main/java/com/auth0/Auth0Filter.java
@@ -1,17 +1,11 @@
 package com.auth0;
 
 
-import java.io.IOException;
-
-import javax.servlet.Filter;
-import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
+import javax.servlet.*;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
+import java.io.IOException;
 
 public class Auth0Filter implements Filter {
 
@@ -20,7 +14,7 @@ public class Auth0Filter implements Filter {
     @Override
     public void init(FilterConfig filterConfig) throws ServletException {
         onFailRedirectTo = filterConfig.getInitParameter("auth0.redirect_on_authentication_error");
-        
+
         if (onFailRedirectTo == null) {
             throw new IllegalArgumentException("auth0.redirect_on_authentication_error parameter of " + this.getClass().getName() + " cannot be null");
         }
@@ -30,7 +24,7 @@ public class Auth0Filter implements Filter {
         HttpSession session = ((HttpServletRequest) req).getSession();
         return (Tokens) session.getAttribute("auth0tokens");
     }
-    
+
     protected Auth0User loadUser(ServletRequest req) {
         HttpSession session = ((HttpServletRequest) req).getSession();
         return (Auth0User) session.getAttribute("user");
@@ -45,7 +39,7 @@ public class Auth0Filter implements Filter {
         HttpServletResponse resp = (HttpServletResponse) response;
         HttpServletRequest request = (HttpServletRequest) req;
         resp.sendRedirect(request.getContextPath() + onFailRedirectTo + "?"
-				+ request.getQueryString());
+                + request.getQueryString());
     }
 
     @Override

--- a/src/main/java/com/auth0/Auth0RequestWrapper.java
+++ b/src/main/java/com/auth0/Auth0RequestWrapper.java
@@ -7,11 +7,11 @@ import java.security.Principal;
 public class Auth0RequestWrapper extends HttpServletRequestWrapper {
     String idToken;
     HttpServletRequest realRequest;
-	private Auth0User user;
+    private Auth0User user;
 
     public Auth0RequestWrapper(Auth0User user, HttpServletRequest request) {
         super(request);
-		this.user = user;
+        this.user = user;
 
         this.realRequest = request;
     }

--- a/src/main/java/com/auth0/Auth0ServletCallback.java
+++ b/src/main/java/com/auth0/Auth0ServletCallback.java
@@ -1,13 +1,9 @@
 package com.auth0;
 
-import static java.util.Arrays.asList;
-import static us.monoid.web.Resty.content;
-import static us.monoid.web.Resty.form;
-
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.Properties;
+import org.apache.commons.lang3.Validate;
+import us.monoid.json.JSONObject;
+import us.monoid.web.JSONResource;
+import us.monoid.web.Resty;
 
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
@@ -15,205 +11,203 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
+import java.io.IOException;
+import java.util.Properties;
 
-import org.apache.commons.lang3.Validate;
-
-import us.monoid.json.JSONObject;
-import us.monoid.web.JSONResource;
-import us.monoid.web.Resty;
+import static java.util.Arrays.asList;
+import static us.monoid.web.Resty.content;
 
 public class Auth0ServletCallback extends HttpServlet {
 
-	private Properties properties = new Properties();
-	private String redirectOnSuccess;
-	private String redirectOnFail;
+    protected Properties properties = new Properties();
+    protected String redirectOnSuccess;
+    protected String redirectOnFail;
 
-	/**
-	 * Fetch properties to be used. User is encourage to override this method.
-	 * 
-	 * Auth0 uses the ServletContext parameters:
-	 * 
-	 * <dl>
-	 * <dt>auth0.client_id</dd>
-	 * <dd>Application client id</dd>
-	 * <dt>auth0.client_secret</dt>
-	 * <dd>Application client secret</dd>
-	 * <dt>auth0.domain</dt>
-	 * <dd>Auth0 domain</dd>
-	 * </dl>
-	 * 
-	 * Auth0ServletCallback uses these ServletConfig parameters:
-	 * 
-	 * <dl>
-	 * <dt>auth0.redirect_on_success</dt>
-	 * <dd>Where to send the user after successful login.</dd>
-	 * <dt>auth0.redirect_on_error</dt>
-	 * <dd>Where to send the user after failed login.</dd>
-	 * </dl>
-	 */
-	@Override
-	public void init(ServletConfig config) throws ServletException {
-		super.init(config);
+    /**
+     * Fetch properties to be used. User is encourage to override this method.
+     * <p>
+     * Auth0 uses the ServletContext parameters:
+     * <p>
+     * <dl>
+     * <dt>auth0.client_id</dd>
+     * <dd>Application client id</dd>
+     * <dt>auth0.client_secret</dt>
+     * <dd>Application client secret</dd>
+     * <dt>auth0.domain</dt>
+     * <dd>Auth0 domain</dd>
+     * </dl>
+     * <p>
+     * Auth0ServletCallback uses these ServletConfig parameters:
+     * <p>
+     * <dl>
+     * <dt>auth0.redirect_on_success</dt>
+     * <dd>Where to send the user after successful login.</dd>
+     * <dt>auth0.redirect_on_error</dt>
+     * <dd>Where to send the user after failed login.</dd>
+     * </dl>
+     */
+    @Override
+    public void init(ServletConfig config) throws ServletException {
+        super.init(config);
 
-		redirectOnSuccess = readParameter("auth0.redirect_on_success", config);
+        redirectOnSuccess = readParameter("auth0.redirect_on_success", config);
 
-		redirectOnFail = readParameter("auth0.redirect_on_error", config);
+        redirectOnFail = readParameter("auth0.redirect_on_error", config);
 
-		for (String param : asList("auth0.client_id", "auth0.client_secret",
-				"auth0.domain")) {
-			properties.put(param, readParameter(param, config));
-		}
-	}
+        for (String param : asList("auth0.client_id", "auth0.client_secret",
+                "auth0.domain")) {
+            properties.put(param, readParameter(param, config));
+        }
+    }
 
-	@Override
-	protected void doGet(HttpServletRequest req, HttpServletResponse resp)
-			throws ServletException, IOException {
-		if (isValidRequest(req, resp)) {
-			try {
-				Tokens tokens = fetchTokens(req);
-				Auth0User user = fetchUser(tokens);
-				store(tokens, user, req);
-				onSuccess(req, resp);
-			} catch (IllegalArgumentException ex) {
-				onFailure(req, resp, ex);
-			} catch (IllegalStateException ex) {
-				onFailure(req, resp, ex);
-			}
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp)
+            throws ServletException, IOException {
+        if (isValidRequest(req, resp)) {
+            try {
+                Tokens tokens = fetchTokens(req);
+                Auth0User user = fetchUser(tokens);
+                store(tokens, user, req);
+                onSuccess(req, resp);
+            } catch (IllegalArgumentException ex) {
+                onFailure(req, resp, ex);
+            } catch (IllegalStateException ex) {
+                onFailure(req, resp, ex);
+            }
 
-		}
-	}
+        }
+    }
 
-	protected void onSuccess(HttpServletRequest req, HttpServletResponse resp)
-			throws ServletException, IOException {
-		// Redirect user to home
-		resp.sendRedirect(req.getContextPath() + redirectOnSuccess);
-	}
+    protected void onSuccess(HttpServletRequest req, HttpServletResponse resp)
+            throws ServletException, IOException {
+        // Redirect user to home
+        resp.sendRedirect(req.getContextPath() + redirectOnSuccess);
+    }
 
-	protected void onFailure(HttpServletRequest req, HttpServletResponse resp,
-			Exception ex) throws ServletException, IOException {
-		ex.printStackTrace();
-		resp.sendRedirect(req.getContextPath() + redirectOnFail + "?"
-				+ req.getQueryString());
-	}
+    protected void onFailure(HttpServletRequest req, HttpServletResponse resp,
+                             Exception ex) throws ServletException, IOException {
+        ex.printStackTrace();
+        resp.sendRedirect(req.getContextPath() + redirectOnFail + "?"
+                + req.getQueryString());
+    }
 
-	protected void store(Tokens tokens, Auth0User user, HttpServletRequest req) {
-		HttpSession session = req.getSession();
+    protected void store(Tokens tokens, Auth0User user, HttpServletRequest req) {
+        HttpSession session = req.getSession();
 
-		// Save tokens on a persistent session
-		session.setAttribute("auth0tokens", tokens);
-		session.setAttribute("user", user);
-	}
+        // Save tokens on a persistent session
+        session.setAttribute("auth0tokens", tokens);
+        session.setAttribute("user", user);
+    }
 
-	private Tokens fetchTokens(HttpServletRequest req) throws IOException {
-		String authorizationCode = getAuthorizationCode(req);
-		Resty resty = createResty();
+    protected Tokens fetchTokens(HttpServletRequest req) throws IOException {
+        String authorizationCode = getAuthorizationCode(req);
+        Resty resty = createResty();
 
-		String tokenUri = getTokenUri();
+        String tokenUri = getTokenUri();
 
-		JSONObject json = new JSONObject();
-		try {
-			json.put("client_id", properties.get("auth0.client_id"));
-			json.put("client_secret", properties.get("auth0.client_secret"));
-			json.put("redirect_uri", req.getRequestURL().toString());
-			json.put("grant_type", "authorization_code");
-			json.put("code", authorizationCode);
+        JSONObject json = new JSONObject();
+        try {
+            json.put("client_id", properties.get("auth0.client_id"));
+            json.put("client_secret", properties.get("auth0.client_secret"));
+            json.put("redirect_uri", req.getRequestURL().toString());
+            json.put("grant_type", "authorization_code");
+            json.put("code", authorizationCode);
 
-			JSONResource tokenInfo = resty.json(tokenUri, content(json));
-			return new Tokens(tokenInfo.toObject());
+            JSONResource tokenInfo = resty.json(tokenUri, content(json));
+            return new Tokens(tokenInfo.toObject());
 
-		} catch (Exception ex) {
-			throw new IllegalStateException("Cannot get Token from Auth0", ex);
-		}
-	}
+        } catch (Exception ex) {
+            throw new IllegalStateException("Cannot get Token from Auth0", ex);
+        }
+    }
 
-	private Auth0User fetchUser(Tokens tokens) {
-		Resty resty = createResty();
+    protected Auth0User fetchUser(Tokens tokens) {
+        Resty resty = createResty();
 
-		String userInfoUri = getUserInfoUri(tokens.getAccessToken());
+        String userInfoUri = getUserInfoUri(tokens.getAccessToken());
 
-		try {
-			JSONResource json = resty.json(userInfoUri);
-			return new Auth0User(json.toObject());
-		} catch (Exception ex) {
-			throw new IllegalStateException("Cannot get User from Auth0", ex);
-		}
-	}
+        try {
+            JSONResource json = resty.json(userInfoUri);
+            return new Auth0User(json.toObject());
+        } catch (Exception ex) {
+            throw new IllegalStateException("Cannot get User from Auth0", ex);
+        }
+    }
 
-	private String getTokenUri() {
-		return getUri("/oauth/token");
-	}
+    protected String getTokenUri() {
+        return getUri("/oauth/token");
+    }
 
-	private String getUserInfoUri(String accessToken) {
-		return getUri("/userinfo?access_token=" + accessToken);
-	}
+    protected String getUserInfoUri(String accessToken) {
+        return getUri("/userinfo?access_token=" + accessToken);
+    }
 
-	private String getUri(String path) {
-		return String.format("https://%s%s", (String) properties.get("auth0.domain"), path);
-	}
+    protected String getUri(String path) {
+        return String.format("https://%s%s", (String) properties.get("auth0.domain"), path);
+    }
 
-	private String getAuthorizationCode(HttpServletRequest req) {
-		String code = req.getParameter("code");
-		Validate.notNull(code);
-		return code;
-	}
+    protected String getAuthorizationCode(HttpServletRequest req) {
+        String code = req.getParameter("code");
+        Validate.notNull(code);
+        return code;
+    }
 
-	/**
-	 * Override this method to specify a different Resty client. For example, if
-	 * you want to add a proxy, this would be the place to set it
-	 * 
-	 * 
-	 * @return {@link Resty} that will be used to perform all requests to Auth0
-	 */
-	protected Resty createResty() {
-		return new Resty();
-	}
+    /**
+     * Override this method to specify a different Resty client. For example, if
+     * you want to add a proxy, this would be the place to set it
+     *
+     * @return {@link Resty} that will be used to perform all requests to Auth0
+     */
+    protected Resty createResty() {
+        return new Resty();
+    }
 
-	private boolean isValidRequest(HttpServletRequest req,
-			HttpServletResponse resp) throws IOException {
-		if (hasError(req) || !isValidState(req)) {
-			return false;
-		}
-		return true;
-	}
+    protected boolean isValidRequest(HttpServletRequest req,
+                                     HttpServletResponse resp) throws IOException {
+        if (hasError(req) || !isValidState(req)) {
+            return false;
+        }
+        return true;
+    }
 
-	private boolean isValidState(HttpServletRequest req) {
-		return req.getParameter("state")
-				.equals(getNonceStorage(req).getState());
-	}
+    protected boolean isValidState(HttpServletRequest req) {
+        return req.getParameter("state")
+                .equals(getNonceStorage(req).getState());
+    }
 
-	private static boolean hasError(HttpServletRequest req) {
-		return req.getParameter("error") != null;
-	}
+    protected static boolean hasError(HttpServletRequest req) {
+        return req.getParameter("error") != null;
+    }
 
-	static String readParameter(String parameter, ServletConfig config) {
-		String first = config.getInitParameter(parameter);
-		if (hasValue(first)) {
-			return first;
-		}
-		final String second = config.getServletContext().getInitParameter(
-				parameter);
-		if (hasValue(second)) {
-			return second;
-		}
-		throw new IllegalArgumentException(parameter + " needs to be defined");
-	}
+    static String readParameter(String parameter, ServletConfig config) {
+        String first = config.getInitParameter(parameter);
+        if (hasValue(first)) {
+            return first;
+        }
+        final String second = config.getServletContext().getInitParameter(
+                parameter);
+        if (hasValue(second)) {
+            return second;
+        }
+        throw new IllegalArgumentException(parameter + " needs to be defined");
+    }
 
-	private static boolean hasValue(String value) {
-		return value != null && value.trim().length() > 0;
-	}
+    protected static boolean hasValue(String value) {
+        return value != null && value.trim().length() > 0;
+    }
 
-	/**
-	 * Override this method to specify a different NonceStorage:
-	 * 
-	 * <code>
-	 *     protected NonceStorage getNonceStorage(HttpServletRequest request) {
-	 *         return MyNonceStorageImpl(request);
-	 *     }
-	 * </code>
-	 */
+    /**
+     * Override this method to specify a different NonceStorage:
+     * <p>
+     * <code>
+     * protected NonceStorage getNonceStorage(HttpServletRequest request) {
+     * return MyNonceStorageImpl(request);
+     * }
+     * </code>
+     */
 
-	protected NonceStorage getNonceStorage(HttpServletRequest request) {
-		return new RequestNonceStorage(request);
-	}
+    protected NonceStorage getNonceStorage(HttpServletRequest request) {
+        return new RequestNonceStorage(request);
+    }
 
 }

--- a/src/main/java/com/auth0/Auth0User.java
+++ b/src/main/java/com/auth0/Auth0User.java
@@ -1,77 +1,75 @@
 package com.auth0;
 
-import java.security.Principal;
-
-import javax.servlet.http.HttpServletRequest;
-
 import us.monoid.json.JSONArray;
 import us.monoid.json.JSONException;
 import us.monoid.json.JSONObject;
 
+import javax.servlet.http.HttpServletRequest;
+import java.security.Principal;
+
 public class Auth0User implements Principal {
 
-	private JSONObject json;
+    private JSONObject json;
 
-	public Auth0User(JSONObject json) {
-		this.json = json;
-	}
+    public Auth0User(JSONObject json) {
+        this.json = json;
+    }
 
-	public static Auth0User get(HttpServletRequest req) {
-		return (Auth0User) req.getSession().getAttribute("user");
-	}
+    public static Auth0User get(HttpServletRequest req) {
+        return (Auth0User) req.getSession().getAttribute("user");
+    }
 
-	public String getProperty(String prop) {
-		return get(prop, String.class);
-	}
+    public String getProperty(String prop) {
+        return get(prop, String.class);
+    }
 
-	public <T> T get(String prop, Class<T> clazz) {
-		try {
-			return (T) json.get(prop);
-		} catch(JSONException ex) {
-			throw new IllegalStateException("Cannot get property " + prop + " from Auth0user", ex);
-		}
-	}
+    public <T> T get(String prop, Class<T> clazz) {
+        try {
+            return (T) json.get(prop);
+        } catch (JSONException ex) {
+            throw new IllegalStateException("Cannot get property " + prop + " from Auth0user", ex);
+        }
+    }
 
-	public JSONObject getObject(String prop) {
-		return get(prop, JSONObject.class);
-	}
+    public JSONObject getObject(String prop) {
+        return get(prop, JSONObject.class);
+    }
 
-	public JSONArray getArray(String prop) {
-		return get(prop, JSONArray.class);
-	}
+    public JSONArray getArray(String prop) {
+        return get(prop, JSONArray.class);
+    }
 
-	public JSONObject getUserMetadata() {
-		return getObject("user_metadata");
-	}
+    public JSONObject getUserMetadata() {
+        return getObject("user_metadata");
+    }
 
-	public JSONObject getAppMetadata() {
-		return getObject("app_metadata");
-	}
+    public JSONObject getAppMetadata() {
+        return getObject("app_metadata");
+    }
 
-	public String getName() {
-		return getProperty("name");
-	}
+    public String getName() {
+        return getProperty("name");
+    }
 
-	public String getEmail() {
-		return getProperty("email");
-	}
+    public String getEmail() {
+        return getProperty("email");
+    }
 
-	public String getUserId() {
-		return getProperty("user_id");
-	}
+    public String getUserId() {
+        return getProperty("user_id");
+    }
 
-	public String getNickname() {
-		return getProperty("nickname");
-	}
+    public String getNickname() {
+        return getProperty("nickname");
+    }
 
-	public String getPicture() {
-		return getProperty("picture");
-	}
+    public String getPicture() {
+        return getProperty("picture");
+    }
 
-	public JSONArray getIdentities() {
-		return getArray("identities");
-	}
-
+    public JSONArray getIdentities() {
+        return getArray("identities");
+    }
 
 
 }

--- a/src/main/java/com/auth0/RequestNonceStorage.java
+++ b/src/main/java/com/auth0/RequestNonceStorage.java
@@ -10,7 +10,7 @@ public class RequestNonceStorage implements NonceStorage {
         this.request = request;
     }
 
-    public String getState () {
+    public String getState() {
         return (String) request.getSession(true).getAttribute("state");
     }
 

--- a/src/main/java/com/auth0/Tokens.java
+++ b/src/main/java/com/auth0/Tokens.java
@@ -31,9 +31,9 @@ public class Tokens {
         this.idToken = idToken;
         this.accessToken = accessToken;
     }
-    
+
     public Tokens(JSONObject json) throws JSONException {
-    	this((String) json.get("id_token"), (String) json.get("access_token"));
+        this((String) json.get("id_token"), (String) json.get("access_token"));
     }
 
     public String getAccessToken() {
@@ -44,7 +44,7 @@ public class Tokens {
         return idToken;
     }
 
-	public boolean exist() {
-		return getIdToken() != null && getAccessToken() != null;
-	}
+    public boolean exist() {
+        return getIdToken() != null && getAccessToken() != null;
+    }
 }

--- a/src/test/java/com/auth0/Auth0ServletCallbackTest.java
+++ b/src/test/java/com/auth0/Auth0ServletCallbackTest.java
@@ -1,21 +1,18 @@
 package com.auth0;
 
-import static java.util.Arrays.asList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
-import java.util.ArrayList;
-import java.util.List;
+import org.junit.Test;
 
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
+import java.util.ArrayList;
+import java.util.List;
 
-import org.junit.Test;
+import static java.util.Arrays.asList;
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class Auth0ServletCallbackTest {
 
@@ -42,7 +39,7 @@ public class Auth0ServletCallbackTest {
                 "auth0.client_id",
                 "auth0.client_secret",
                 "auth0.domain");
-        for(final String missing : parameters) {
+        for (final String missing : parameters) {
             final List<String> defined = new ArrayList<String>(parameters);
             defined.remove(missing);
             paramsDefinedInConfig(missing, defined);
@@ -54,7 +51,7 @@ public class Auth0ServletCallbackTest {
             throws ServletException {
         final ServletConfig configWithoutParams = mock(ServletConfig.class);
         final ServletContext ctxWithParams = mock(ServletContext.class);
-        for(final String parameter : defined) {
+        for (final String parameter : defined) {
             when(ctxWithParams.getInitParameter(eq(parameter))).thenReturn("i-am-defined");
         }
         when(configWithoutParams.getServletContext()).thenReturn(ctxWithParams);
@@ -63,7 +60,7 @@ public class Auth0ServletCallbackTest {
 
     private static void paramsDefinedInConfig(final String missing, final List<String> defined) throws ServletException {
         final ServletConfig configWithParams = mock(ServletConfig.class);
-        for(final String parameter : defined) {
+        for (final String parameter : defined) {
             when(configWithParams.getInitParameter(eq(parameter))).thenReturn("i-am-defined");
         }
         when(configWithParams.getServletContext()).thenReturn(mock(ServletContext.class));
@@ -75,8 +72,7 @@ public class Auth0ServletCallbackTest {
         try {
             cb.init(config);
             fail("Expected init to fail on missing parameter: " + missing);
-        }
-        catch(final IllegalArgumentException e) {
+        } catch (final IllegalArgumentException e) {
             assertTrue("Expected failure to reference parameter: " + missing, e.getMessage().contains(missing));
         }
     }

--- a/src/test/java/com/auth0/RequestNonceStorageTest.java
+++ b/src/test/java/com/auth0/RequestNonceStorageTest.java
@@ -1,15 +1,13 @@
 package com.auth0;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.anyBoolean;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import org.junit.Test;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Mockito.*;
 
 public class RequestNonceStorageTest {
 


### PR DESCRIPTION
In order to successfully code a SSO solution using this library, and having a primary Portal site, and secondary partner site, I found the existing Auth0ServletCallback implementation hid too many needed override methods / variables were private. Have altered this so that sub-classing is achievable in a way that is useful.  Secondly, have removed redundant imports, and generally tidied up codebase layout.