### PR TITLE
Add Signing Algorithm selection support to library

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,18 @@ Here is a breakdown of attributes and what they do:
 
 `auth0.redirect_on_authentication_error` - This is the URL context path for the page to redirect to upon login failure. Should start with `/`
 
+The default JWT Signing Algorithm is `HS256`. This is HMAC SHA256, a symmetric crypographic algorithm (HMAC), that uses the `clientSecret` to
+verify a signed JWT token. However, if you wish to configure this library to use an alternate cryptographic algorithm then use the two
+options below. The Auth0 Dashboard offers the choice between `HS256` and `RS256`. 'RS256' is RSA SHA256 and uses a public key cryptographic
+algorithm (RSA), that requires knowledge of the application public key to verify a signed JWT Token (that was signed with a private key).
+You can download the application's public key from the Auth0 Dashboard and store it inside your application's WEB-INF directory. 
+
+The following two attributes are required when configuring your application with this library to use `RSA` instead of `HMAC`:
+
+`auth0.signing_algorithm` - This is signing algorithm to verify signed JWT token. Use `HS256` or `RS256`. 
+
+`auth0.public_key_path` - This is the path location to the public key stored locally on disk / inside your application War file WEB-INF directory. Should always be set when using `RS256`. 
+
 
 ## Extension Points in Library
 

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>com.auth0</groupId>
             <artifactId>java-jwt</artifactId>
-            <version>2.1.0</version>
+            <version>2.2.0</version>
         </dependency>
 
         <!--Other Third Party-->

--- a/src/main/java/com/auth0/Auth0Client.java
+++ b/src/main/java/com/auth0/Auth0Client.java
@@ -1,5 +1,8 @@
 package com.auth0;
 
+/**
+ * Wrapper around API calls to retrieve tokens and user profile
+ */
 public interface Auth0Client {
 
     public Tokens getTokens(String authorizationCode, String redirectUri);

--- a/src/main/java/com/auth0/Auth0ClientImpl.java
+++ b/src/main/java/com/auth0/Auth0ClientImpl.java
@@ -7,6 +7,7 @@ import org.apache.commons.lang3.Validate;
 
 /**
  * Wrapper implementation around Auth0 service calls
+ * to retrieve UserProfile and Tokens information
  */
 public class Auth0ClientImpl implements Auth0Client {
 


### PR DESCRIPTION
Currently, only `HS256` support is available. This PR permits the configuration of `RS256` support when used with Auth0.  The default algorithm remains as `HS256` if no configuration provided, hence backwards compatible and only requires a minor version update when publishing to Maven.