### PR TITLE
Auth0 client secret shall not be base64 encoded by default

### DIFF
--- a/src/main/java/com/auth0/Auth0Filter.java
+++ b/src/main/java/com/auth0/Auth0Filter.java
@@ -50,7 +50,14 @@ public class Auth0Filter implements Filter {
             case HS512:
                 final String clientSecret = filterConfig.getServletContext().getInitParameter("auth0.client_secret");
                 Validate.notNull(clientSecret);
-                jwtVerifier = new JWTVerifier(new Base64(true).decodeBase64(clientSecret), clientId, issuer);
+                final String base64EncodedSecretStr = filterConfig.getServletContext().getInitParameter("auth0.base64_encoded_secret");
+                Validate.notNull(base64EncodedSecretStr);
+                final boolean base64EncodedSecret = Boolean.valueOf(base64EncodedSecretStr);
+                if (base64EncodedSecret) {
+                    jwtVerifier = new JWTVerifier(new Base64(true).decodeBase64(clientSecret), clientId, issuer);
+                } else {
+                    jwtVerifier = new JWTVerifier(clientSecret, clientId, issuer);
+                }
                 return;
             case RS256:
             case RS384:


### PR DESCRIPTION
Only merge this PR when Auth0 officially switches to client secrets that are not base64 encoded.